### PR TITLE
Fix display for retina display on Linux

### DIFF
--- a/Tingeltangel.sh
+++ b/Tingeltangel.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-java -jar tingeltangel-0.1-beta2-jar-with-dependencies.jar > tt.log 2>&1
+JAR=target/tingeltangel-0.1-beta2-jar-with-dependencies.jar
+
+java -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dsun.java2d.xrender=true \
+    -jar $JAR > tt.log 2>&1


### PR DESCRIPTION
As tested with Ubuntu 15.10 fonts are not displayed properly on high
resolution (aka "retina") displays with OpenJDK. See this bug report:
https://bugs.launchpad.net/ubuntu/+source/openjdk-7/+bug/1497816

This fix makes fonts readable but still very small until this bug has
been fixed in OpenJDK: https://bugs.openjdk.java.net/browse/JDK-8058742