### PR TITLE
Use current directory if Windows Registry is not accessible

### DIFF
--- a/src/main/java/tingeltangel/tools/FileEnvironment.java
+++ b/src/main/java/tingeltangel/tools/FileEnvironment.java
@@ -146,7 +146,7 @@ public class FileEnvironment {
                 myDocuments = new String(b);
                 myDocuments = myDocuments.split("\\s\\s+")[4];
             } catch (Exception e) {
-                throw new Error(e);
+                myDocuments = ".";
             }
             wd = new File(myDocuments, "tingeltangel");
         } else {


### PR DESCRIPTION
In getWorkingDirectoryRoot(), use the current directory for myDocuments if the Windows Registry is not accessible.