### PR TITLE
Add support for iOS

### DIFF
--- a/src/main/java/tingeltangel/core/Stick.java
+++ b/src/main/java/tingeltangel/core/Stick.java
@@ -482,7 +482,7 @@ public class Stick {
             mounts = File.listRoots();
         } else {
             LinkedList<File> mountList = new LinkedList<File>();
-            Process process = new ProcessBuilder("/bin/mount").start();
+            Process process = new ProcessBuilder(OS.getMountCommand()).start();
             BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String row;
             while ((row = in.readLine()) != null) {

--- a/src/test/java/tingeltangel/core/OSTest.java
+++ b/src/test/java/tingeltangel/core/OSTest.java
@@ -1,6 +1,6 @@
 /*
-    Copyright (C) 2015   Martin Dames <martin@bastionbytes.de>
-  
+    Copyright (C) 2015   Jesper Zedlitz <jesper@zedlitz.de>
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -14,26 +14,21 @@
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  
+
 */
+package tingeltangel.core;
 
-package tingeltangel.tools;
+import org.junit.Test;
+import tingeltangel.tools.OS;
+import static org.junit.Assert.assertEquals;
 
-/**
- *
- * @author mdames
- */
-public class OS {
+public class OSTest {
 
-    public static boolean isWindows() {
-        return System.getProperty("os.name").startsWith("Windows");
+    @Test
+    public void testMountForIOS() {
+        System.setProperty("os.name", "Mac OS X");
+        String command = OS.getMountCommand();
+        assertEquals(command, "/sbin/mount");
+
     }
-
-    public static boolean isMac() {
-        return System.getProperty("os.name").startsWith("Mac");
-    }
-    public static String getMountCommand() {
-        return  OS.isMac() ? "/sbin/mount" : "/bin/mount";
-    }
-    
 }


### PR DESCRIPTION
When running gui-editor on Mac there is exception about missing mount command.
In this commit I am fixing the problem. I have also tested the gui-editor with iOS with my changes and it looks OK.

Here is thrown exception on Mac about missing mount command:
```
java.io.IOException: Cannot run program "/bin/mount": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at tingeltangel.core.Stick.getStick(Stick.java:486)
	at tingeltangel.gui.StickPanel$2.run(StickPanel.java:131)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 9 more```