### PR TITLE
Use Ubuntu Trusty for JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - openjdk7


### PR DESCRIPTION
The Travis default distribution is now Ubuntu Xenial, without JDK 7