### PR TITLE
remove travis and add github actions to build in windows, linux, macos

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,32 @@
+name: PR Check
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Building release for ${{ matrix.os }}
+    runs-on: ${{ matrix.image }}
+    strategy:
+      matrix:
+        image: [ ubuntu-latest, windows-latest, macos-latest ]
+        include:
+          - image: ubuntu-latest
+            os: linux
+          - image: windows-latest
+            os: windows
+          - image: macos-latest
+            os: macos
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 13
+
+      - name: Building Application
+        run: |
+          mvn package
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-dist: trusty
-language: java
-jdk:
-  - openjdk7
-  - oraclejdk8


### PR DESCRIPTION
on evert PR it'll try to call `mvn package` which also causes the tests to run. In all OS's

[Example here](https://github.com/andretietz/Tingeltangel/actions)